### PR TITLE
Add argparse to read command line arguments. Add -y.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules/

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/booknds/swagger-data-generator#readme",
   "dependencies": {
+    "argparse": "^1.0.9",
     "json-schema-faker": "^0.3.1",
     "lodash": "^4.11.1",
     "swagger-parser": "^3.4.1"


### PR DESCRIPTION
`-y` overwrites the output file without asking the user first, so it is easier to use this in automated scripts.